### PR TITLE
Allow custom extension to the library using Interceptor like pattern.

### DIFF
--- a/androiddevmetrics-runtime-noop/src/main/java/com/frogermcs/androiddevmetrics/AndroidDevMetrics.java
+++ b/androiddevmetrics-runtime-noop/src/main/java/com/frogermcs/androiddevmetrics/AndroidDevMetrics.java
@@ -88,6 +88,10 @@ public class AndroidDevMetrics {
       return this;
     }
 
+    public Builder addUIInterceptor(Object interceptor) {
+      return this;
+    }
+
     /** stub **/
     public AndroidDevMetrics build() {
       return new AndroidDevMetrics(null);

--- a/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/AndroidDevMetrics.java
+++ b/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/AndroidDevMetrics.java
@@ -14,6 +14,11 @@ import com.frogermcs.androiddevmetrics.internal.metrics.ActivityLaunchMetrics;
 import com.frogermcs.androiddevmetrics.internal.metrics.ChoreographerMetrics;
 import com.frogermcs.androiddevmetrics.internal.metrics.InitManager;
 import com.frogermcs.androiddevmetrics.internal.ui.MetricsActivity;
+import com.frogermcs.androiddevmetrics.internal.ui.interceptor.DefaultInterceptor;
+import com.frogermcs.androiddevmetrics.internal.ui.interceptor.UIInterceptor;
+
+import java.util.ArrayList;
+import java.util.List;
 
 
 /**
@@ -37,6 +42,7 @@ public class AndroidDevMetrics {
     private boolean enableDagger2Metrics;
     private int intervalMillis;
     private double maxFpsForFrameDrop;
+    private List<UIInterceptor> interceptors;
 
     /**
      * Enable Activity and Dagger 2 metrics
@@ -128,6 +134,10 @@ public class AndroidDevMetrics {
         mNotificationManager.notify("AndroidDevMetrics".hashCode(), mBuilder.build());
     }
 
+    public List<UIInterceptor> interceptors() {
+        return interceptors;
+    }
+
     public static class Builder {
         private final Context context;
         private int dagger2WarningLevel1 = DAGGER2_WARNING_1_LIMIT_MILLIS;
@@ -139,12 +149,15 @@ public class AndroidDevMetrics {
         private boolean autoCancelNotification = false;
         private int intervalMillis = FRAME_DROPS_DEFAULT_INTERVAL_MS;
         private double maxFpsForFrameDrop = FRAME_DROPS_FPS_LIMIT;
+        private List<UIInterceptor> interceptors;
 
         public Builder(Context context) {
             if (context == null) {
                 throw new IllegalArgumentException("Context must not be null.");
             } else {
                 this.context = context.getApplicationContext();
+                this.interceptors = new ArrayList<>();
+                this.interceptors.add(new DefaultInterceptor());
             }
         }
 
@@ -190,6 +203,11 @@ public class AndroidDevMetrics {
             return this;
         }
 
+        public Builder addUIInterceptor(UIInterceptor interceptor) {
+            this.interceptors.add(interceptor);
+            return this;
+        }
+
         public AndroidDevMetrics build() {
             AndroidDevMetrics androidDevMetrics = new AndroidDevMetrics(context);
             androidDevMetrics.dagger2WarningLevel1 = this.dagger2WarningLevel1;
@@ -201,6 +219,7 @@ public class AndroidDevMetrics {
             androidDevMetrics.maxFpsForFrameDrop = this.maxFpsForFrameDrop;
             androidDevMetrics.intervalMillis = this.intervalMillis;
             androidDevMetrics.autoCancelNotification = this.autoCancelNotification;
+            androidDevMetrics.interceptors = this.interceptors;
             return androidDevMetrics;
         }
     }

--- a/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/metrics/InitManager.java
+++ b/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/metrics/InitManager.java
@@ -1,7 +1,9 @@
 package com.frogermcs.androiddevmetrics.internal.metrics;
 
+import com.frogermcs.androiddevmetrics.AndroidDevMetrics;
 import com.frogermcs.androiddevmetrics.internal.MetricDescription;
 import com.frogermcs.androiddevmetrics.internal.metrics.model.InitMetric;
+import com.frogermcs.androiddevmetrics.internal.ui.interceptor.UIInterceptor;
 
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -62,9 +64,10 @@ public class InitManager {
         }
     }
 
-    public List<MetricDescription> getListOfMetricDescriptions() {
+    public List<MetricDescription> getListOfMetricDescriptions(UIInterceptor interceptor) {
         List<MetricDescription> metricDescriptions = new ArrayList<>();
-        for (InitMetric initMetric : InitManager.getInstance().initializedMetrics.values()) {
+        List<InitMetric> displayList = interceptor.intercept(new ArrayList<>(InitManager.getInstance().initializedMetrics.values()));
+        for (InitMetric initMetric : displayList) {
             metricDescriptions.add(MetricDescription.InitFromMetric(initMetric));
         }
         return metricDescriptions;

--- a/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/metrics/InitManager.java
+++ b/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/metrics/InitManager.java
@@ -1,6 +1,5 @@
 package com.frogermcs.androiddevmetrics.internal.metrics;
 
-import com.frogermcs.androiddevmetrics.AndroidDevMetrics;
 import com.frogermcs.androiddevmetrics.internal.MetricDescription;
 import com.frogermcs.androiddevmetrics.internal.metrics.model.InitMetric;
 import com.frogermcs.androiddevmetrics.internal.ui.interceptor.UIInterceptor;
@@ -33,6 +32,7 @@ public class InitManager {
         initMetric.initTimeMillis = initTimeMillis;
         initMetric.cls = initializedClass;
         initMetric.threadName = Thread.currentThread().getName();
+        initMetric.traceElements = Thread.currentThread().getStackTrace();
 
         String simpleName = initializedClass.getName();
         if (!initializedMetrics.containsKey(simpleName)) {

--- a/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/metrics/model/InitMetric.java
+++ b/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/metrics/model/InitMetric.java
@@ -15,6 +15,7 @@ public class InitMetric {
     public int instanceNo = 0;
     public String threadName = "";
     public Set<InitMetric> args = new HashSet<>();
+    public StackTraceElement[] traceElements;
 
     public long getTotalInitTime() {
         long total = initTimeMillis;

--- a/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/ui/fragment/Dagger2MetricsFragment.java
+++ b/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/ui/fragment/Dagger2MetricsFragment.java
@@ -1,18 +1,25 @@
 package com.frogermcs.androiddevmetrics.internal.ui.fragment;
 
+import android.app.AlertDialog;
+import android.content.DialogInterface;
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ExpandableListView;
 import android.widget.TextView;
 
+import com.frogermcs.androiddevmetrics.AndroidDevMetrics;
 import com.frogermcs.androiddevmetrics.R;
 import com.frogermcs.androiddevmetrics.aspect.Dagger2GraphAnalyzer;
 import com.frogermcs.androiddevmetrics.internal.metrics.InitManager;
 import com.frogermcs.androiddevmetrics.internal.ui.ExpandableMetricsListAdapter;
+import com.frogermcs.androiddevmetrics.internal.ui.interceptor.UIInterceptor;
+
+import java.util.List;
 
 /**
  * Created by Miroslaw Stanek on 25.01.2016.
@@ -21,6 +28,9 @@ public class Dagger2MetricsFragment extends Fragment {
 
     private ExpandableListView lvMetrics;
     private TextView tvEmpty;
+    private Button btnMenu;
+    private List<UIInterceptor> interceptorList;
+    private ExpandableMetricsListAdapter adapter;
 
     @Nullable
     @Override
@@ -28,6 +38,18 @@ public class Dagger2MetricsFragment extends Fragment {
         final View view = inflater.inflate(R.layout.adm_fragment_dagger2_metrics, container, false);
         lvMetrics = (ExpandableListView) view.findViewById(R.id.lvMetrics);
         tvEmpty = (TextView) view.findViewById(R.id.tvEmpty);
+        interceptorList = AndroidDevMetrics.singleton().interceptors();
+        if (interceptorList.size() > 1) {
+            btnMenu = (Button) view.findViewById(R.id.btnMenu);
+            btnMenu.setVisibility(View.VISIBLE);
+            btnMenu.setText(interceptorList.get(0).getName());
+            btnMenu.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    showUIInterceptorMenu();
+                }
+            });
+        }
         return view;
     }
 
@@ -35,9 +57,9 @@ public class Dagger2MetricsFragment extends Fragment {
     public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
         super.onViewCreated(view, savedInstanceState);
 
-        ExpandableMetricsListAdapter adapter = new ExpandableMetricsListAdapter();
+        adapter = new ExpandableMetricsListAdapter();
         lvMetrics.setAdapter(adapter);
-        adapter.updateMetrics(InitManager.getInstance().getListOfMetricDescriptions());
+        adapter.updateMetrics(InitManager.getInstance().getListOfMetricDescriptions(interceptorList.get(0)));
 
         if (!Dagger2GraphAnalyzer.isEnabled()) {
             tvEmpty.setVisibility(View.VISIBLE);
@@ -51,5 +73,22 @@ public class Dagger2MetricsFragment extends Fragment {
             tvEmpty.setVisibility(View.GONE);
             lvMetrics.setVisibility(View.VISIBLE);
         }
+    }
+
+    private void showUIInterceptorMenu() {
+        String[] transformerNames = new String[interceptorList.size()];
+        for (int i = 0; i < interceptorList.size(); i++) {
+            transformerNames[i] = interceptorList.get(i).getName();
+        }
+        AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
+        builder.setTitle("Settings")
+                .setItems(transformerNames, new DialogInterface.OnClickListener() {
+                    public void onClick(DialogInterface dialog, int which) {
+                        btnMenu.setText(interceptorList.get(which).getName());
+                        adapter.updateMetrics(InitManager.getInstance().getListOfMetricDescriptions(interceptorList.get(which)));
+                        adapter.notifyDataSetChanged();
+                    }
+                });
+        builder.create().show();
     }
 }

--- a/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/ui/interceptor/DefaultInterceptor.java
+++ b/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/ui/interceptor/DefaultInterceptor.java
@@ -1,0 +1,23 @@
+package com.frogermcs.androiddevmetrics.internal.ui.interceptor;
+
+import com.frogermcs.androiddevmetrics.internal.metrics.model.InitMetric;
+
+import java.util.List;
+
+/**
+ * @author amulya
+ * @since 13 Jan 2017, 12:58 PM.
+ */
+
+public final class DefaultInterceptor implements UIInterceptor {
+
+    @Override
+    public List<InitMetric> intercept(List<InitMetric> metrics) {
+        return metrics;
+    }
+
+    @Override
+    public String getName() {
+        return "Default";
+    }
+}

--- a/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/ui/interceptor/UIInterceptor.java
+++ b/androiddevmetrics-runtime/src/main/java/com/frogermcs/androiddevmetrics/internal/ui/interceptor/UIInterceptor.java
@@ -1,0 +1,17 @@
+package com.frogermcs.androiddevmetrics.internal.ui.interceptor;
+
+import com.frogermcs.androiddevmetrics.internal.metrics.model.InitMetric;
+
+import java.util.List;
+
+/**
+ * @author amulya
+ * @since 13 Jan 2017, 12:51 PM.
+ */
+
+public interface UIInterceptor {
+
+    List<InitMetric> intercept(List<InitMetric> metrics);
+
+    String getName();
+}

--- a/androiddevmetrics-runtime/src/main/res/layout/adm_fragment_dagger2_metrics.xml
+++ b/androiddevmetrics-runtime/src/main/res/layout/adm_fragment_dagger2_metrics.xml
@@ -6,6 +6,16 @@
     android:background="#f5f5f5"
     android:orientation="vertical">
 
+    <Button
+        android:id="@+id/btnMenu"
+        android:background="@color/d2m_bg_warning_1"
+        android:text="@string/adm_name"
+        android:layout_width="match_parent"
+        android:textSize="12sp"
+        android:visibility="gone"
+        android:padding="0dp"
+        android:layout_height="wrap_content" />
+
     <ExpandableListView
         android:id="@+id/lvMetrics"
         android:layout_width="match_parent"


### PR DESCRIPTION
Allow custom extension to the library using Interceptor like pattern.

**Problem:**
This library is great in measuring injection time for dagger. But there are limitation is the way the results are displayed on the screen. For example, if the application is really comprehensive, the dependency list can be really long. There are no features to group or filter the dependencies. Similarly, different use-cases may need different features to visualise the dependency tree or to dump it for future analysis.

**Solution:**
It is infeasible to add these features to the project one-at-a-time since requirements may vary across different projects. Allow users of the library to extend its functionality by adding custom "interceptors".

```
AndroidDevMetrics.Builder builder = new AndroidDevMetrics.Builder(application)
                .enableActivityMetrics(true)
                .enableDagger2Metrics(true)
                ...
                .addUIInterceptor(new GroupByActivity())
                .addUIInterceptor(new FilterByTime(20))
                .addUIInterceptor(new DumpToLog())
                ...
                .showNotification(true);
        AndroidDevMetrics.initWith(builder);
```

When a custom interceptor is added, it will automatically show-up in the UI menu as follows:

<img width=200 src="http://i.imgur.com/cvedOHL.png"/>

When an option is selected, the existing dependency graph will go through a `intercept()` method which transforms the graph into a new graph (thus allowing grouping/filtering etc. features)

**Example:**
```
public class FilterByTime implements UIInterceptor {

    private final int timeMs;

    public FilterByTime(int timeMs) {
        this.timeMs = timeMs;
    }

    @Override
    public List<InitMetric> intercept(List<InitMetric> metrics) {
        List<InitMetric> newList = new ArrayList<>();
        for (InitMetric metric : metrics) {
            if (metric.getTotalInitTime() >= timeMs) {
                newList.add(metric);
            }
        }
        return newList;
    }

    @Override
    public String getName() {
        return "Filter > " + timeMs + "ms";
    }
}
```

The returned `newList` is then used to display the graph in the UI.

<img width=600 src="http://i.imgur.com/vTq4QRr.jpg"/>

If no interceptors are added, the functionality of the library remains same as before.