### PR TITLE
Replaced support-v4 dependency with smaller subset (support-compat) 

### DIFF
--- a/androiddevmetrics-runtime/build.gradle
+++ b/androiddevmetrics-runtime/build.gradle
@@ -23,8 +23,8 @@ repositories {
 
 dependencies {
     compile 'org.aspectj:aspectjrt:1.8.8'
-    compile 'com.android.support:support-v4:24.0.0'
-    compile 'com.android.support:appcompat-v7:24.0.0'
+    compile 'com.android.support:support-compat:24.2.0'
+    compile 'com.android.support:appcompat-v7:24.2.0'
 }
 
 android {


### PR DESCRIPTION
I think it would be good idea to follow Ian Lake recommendation and replaced support-v4 dependency with smaller subset (support-compat).

Library subsets have been extracted from support-v4 for the first time in 24.2.0. From what I can see
[here](https://developer.android.com/topic/libraries/support-library/rev-archive.html) there are no API changes from 24.0.0 to 24.2.0.