### PR TITLE
Removed debug logs - project can't be assembled if BINTRAY_GPG_PASSWORD isn't defined

### DIFF
--- a/androiddevmetrics-runtime-noop/build.gradle
+++ b/androiddevmetrics-runtime-noop/build.gradle
@@ -147,10 +147,6 @@ bintray {
 task sourcesJar(type: Jar) {
     from android.sourceSets.main.java.srcDirs
     classifier = 'sources'
-
-    println "mirek"
-    println BINTRAY_GPG_PASSWORD
-    println project.hasProperty('BINTRAY_GPG_PASSWORD')
 }
 
 task javadoc(type: Javadoc) {


### PR DESCRIPTION
I think it's self-explanatory.