### PR TITLE
Added `building AndroidDevMetrics` section

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,13 @@ Finally, if you want to understand where most of performance issues come from, h
 
 You can check [GithubClient](https://github.com/frogermcs/githubclient) - example Android app which shows how to use Dagger 2. Most recent version uses **AndroidDevMetrics** for measuring performance.
 
+## Building AndroidDevMetrics
+
+Build AndroidDevMetrics plugin with [`./gradlew clean build`]. The tests can be run with
+`./gradlew clean test`. To install the plugin in your local maven repository (usually located at
+`~/.m2/repository`) use `./gradlew clean install`. You can change `VERSION_NAME` value in `gradle.properties`
+to easily recognise your version.
+
 ## License
 
     Copyright 2016 Miroslaw Stanek


### PR DESCRIPTION
Nothing fancy here - I've applied what has been suggested in #43. It's blocked https://github.com/frogermcs/GithubClient/pull/30 and lint check on one of modules fails - I still need to add it. @frogermcs what do you think?