### PR TITLE
Fix annoying gradle warnings

### DIFF
--- a/androiddevmetrics-plugin/build.gradle
+++ b/androiddevmetrics-plugin/build.gradle
@@ -14,10 +14,10 @@ repositories {
 dependencies {
     compile gradleApi()
     compile localGroovy()
-    compile 'com.android.tools.build:gradle:3.0.1'
+    compile 'com.android.tools.build:gradle:3.3.2'
     compile 'org.aspectj:aspectjtools:1.8.8'
     compile 'org.aspectj:aspectjrt:1.8.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:1.2.21"
+    compile "org.jetbrains.kotlin:kotlin-stdlib:1.3.21"
     testCompile "junit:junit:4.12"
 }
 

--- a/androiddevmetrics-plugin/build.gradle
+++ b/androiddevmetrics-plugin/build.gradle
@@ -12,13 +12,13 @@ repositories {
 }
 
 dependencies {
-    compile gradleApi()
-    compile localGroovy()
-    compile 'com.android.tools.build:gradle:3.3.2'
-    compile 'org.aspectj:aspectjtools:1.8.8'
-    compile 'org.aspectj:aspectjrt:1.8.8'
-    compile "org.jetbrains.kotlin:kotlin-stdlib:1.3.21"
-    testCompile "junit:junit:4.12"
+    implementation gradleApi()
+    implementation localGroovy()
+    implementation 'com.android.tools.build:gradle:3.3.2'
+    implementation 'org.aspectj:aspectjtools:1.8.8'
+    implementation 'org.aspectj:aspectjrt:1.8.8'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:1.3.21"
+    testImplementation "junit:junit:4.12"
 }
 
 group = GROUP

--- a/androiddevmetrics-plugin/src/main/kotlin/com/frogermcs/androiddevmetrics/weaving/plugin/AndroidDevMetricsPlugin.kt
+++ b/androiddevmetrics-plugin/src/main/kotlin/com/frogermcs/androiddevmetrics/weaving/plugin/AndroidDevMetricsPlugin.kt
@@ -41,7 +41,7 @@ class AndroidDevMetricsPlugin: Plugin<Project> {
                     return@all
                 }
 
-                val javaCompiler = variant.javaCompiler as AbstractCompile
+                val javaCompiler = variant.javaCompileProvider.get() as AbstractCompile
                 javaCompiler.doLast({
                     val args = arrayOf(
                             "-showWeaveInfo",

--- a/androiddevmetrics-runtime-noop/build.gradle
+++ b/androiddevmetrics-runtime-noop/build.gradle
@@ -46,7 +46,7 @@ android {
 }
 
 android.libraryVariants.all { variant ->
-    JavaCompile javaCompile = variant.javaCompile
+    JavaCompile javaCompile = variant.javaCompileProvider.get()
     javaCompile.doLast {
         String[] args = ["-showWeaveInfo",
                          "-1.5",

--- a/androiddevmetrics-runtime/build.gradle
+++ b/androiddevmetrics-runtime/build.gradle
@@ -21,9 +21,9 @@ repositories {
 }
 
 dependencies {
-    compile 'org.aspectj:aspectjrt:1.8.8'
-    compile 'com.android.support:support-compat:26.1.0'
-    compile 'com.android.support:appcompat-v7:26.1.0'
+    implementation 'org.aspectj:aspectjrt:1.8.8'
+    implementation 'com.android.support:support-compat:26.1.0'
+    implementation 'com.android.support:appcompat-v7:26.1.0'
 }
 
 android {

--- a/androiddevmetrics-runtime/build.gradle
+++ b/androiddevmetrics-runtime/build.gradle
@@ -50,7 +50,7 @@ android {
 }
 
 android.libraryVariants.all { variant ->
-    JavaCompile javaCompile = variant.javaCompile
+    JavaCompile javaCompile = variant.javaCompileProvider.get()
     javaCompile.doLast {
         String[] args = ["-showWeaveInfo",
                          "-1.5",

--- a/build.gradle
+++ b/build.gradle
@@ -10,13 +10,13 @@ buildscript {
         google()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.0.1'
+        classpath 'com.android.tools.build:gradle:3.3.2'
         classpath 'org.aspectj:aspectjtools:1.8.8'
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.5'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'
         classpath 'com.bmuschko:gradle-nexus-plugin:2.3.1'
         classpath 'com.frogermcs.androiddevmetrics:androiddevmetrics-plugin:0.6'
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.2.21"
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:1.3.21"
     }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip


### PR DESCRIPTION
When using your plugin gradle spam me warning every sync.

```
WARNING: API 'variant.getJavaCompile()' is obsolete and has been replaced with 'variant.getJavaCompileProvider()'.
It will be removed at the end of 2019.
For more information, see https://d.android.com/r/tools/task-configuration-avoidance.
To determine what is calling variant.getJavaCompile(), use -Pandroid.debug.obsoleteApi=true on the command line to display a stack trace.
Affected Modules: app


WARNING: Configuration 'compile' is obsolete and has been replaced with 'implementation' and 'api'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
Affected Modules: app


WARNING: Configuration 'debugCompile' is obsolete and has been replaced with 'debugImplementation' and 'debugApi'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
Affected Modules: app


WARNING: Configuration 'releaseCompile' is obsolete and has been replaced with 'releaseImplementation' and 'releaseApi'.
It will be removed at the end of 2018. For more information see: http://d.android.com/r/tools/update-dependency-configurations.html
Affected Modules: app
```

Fix this in pull request